### PR TITLE
Secure connection by default, default url for dir

### DIFF
--- a/lib/ds.ts
+++ b/lib/ds.ts
@@ -32,11 +32,21 @@ interface GetRelationParams {
   relation: RelationParams;
 }
 
-const ds = (authorizerCertCAFile: string) => {
+const asertoProductionDirectoryServiceUrl = "authorizer.prod.aserto.com:8443";
+
+const ds = (authorizerCertCAFile: string, directoryServiceUrl?: string) => {
   const creds = authorizerCertCAFile
     ? getSSLCredentials(authorizerCertCAFile)
-    : credentials.createInsecure();
-  const client = new ReaderClient("localhost:9292", creds);
+    : credentials.createSsl();
+  let directoryService =
+    directoryServiceUrl ?? asertoProductionDirectoryServiceUrl;
+
+  // If the directory service URL starts with https, remove it
+  if (directoryService?.startsWith("https://")) {
+    directoryService = directoryService.split("https://")[1]!;
+  }
+
+  const client = new ReaderClient(directoryService, creds);
 
   const getObject = (params: ObjectParams) => {
     const { type, id, key } = params ?? {};

--- a/lib/ds.ts
+++ b/lib/ds.ts
@@ -32,7 +32,7 @@ interface GetRelationParams {
   relation: RelationParams;
 }
 
-const asertoProductionDirectoryServiceUrl = "authorizer.prod.aserto.com:8443";
+const asertoProductionDirectoryServiceUrl = "directory.prod.aserto.com:8443";
 
 const ds = (authorizerCertCAFile: string, directoryServiceUrl?: string) => {
   const creds = authorizerCertCAFile

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -26,7 +26,10 @@ declare function is(
   resourceMap?: is.ResourceMap
 ): boolean;
 
-declare function ds(authorizerCertCAFile: string): {
+declare function ds(
+  authorizerCertCAFile: string,
+  directoryServiceUrl?: string
+): {
   object: function;
   relation: function;
 };

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -28,6 +28,8 @@ declare function is(
 
 declare function ds(
   authorizerCertCAFile: string,
+  tenantId?: string,
+  directoryApiKey?: string,
   directoryServiceUrl?: string
 ): {
   object: function;

--- a/lib/processOptions.ts
+++ b/lib/processOptions.ts
@@ -38,11 +38,11 @@ export default (
   }
   let authorizerUrl = `${authorizerServiceUrl}`;
   // strip any https:// or http:// prefix since this is a gRPC address
-  if (authorizerUrl.startsWith('https://')) {
-    authorizerUrl = authorizerUrl.split('https://')[1]!
+  if (authorizerUrl.startsWith("https://")) {
+    authorizerUrl = authorizerUrl.split("https://")[1]!;
   }
-  if (authorizerUrl.startsWith('http://')) {
-    authorizerUrl = authorizerUrl.split('http://')[1]!
+  if (authorizerUrl.startsWith("http://")) {
+    authorizerUrl = authorizerUrl.split("http://")[1]!;
   }
 
   // set the authorizer API key
@@ -86,7 +86,7 @@ export default (
   if (!disableTlsValidation && authorizerCertCAFile) {
     authorizerCert = getSSLCredentials(authorizerCertCAFile);
   } else {
-    authorizerCert = credentials.createInsecure();
+    authorizerCert = credentials.createSsl();
     log("INSECURE CONNECTION");
   }
 


### PR DESCRIPTION
* use `createSsl()` when certificate is not provided instead of `createInsecure()`
* use `authorizer.prod.aserto.com:8443` as the default URL for the directory unless it is explicitly passed