### PR TITLE
fix insecure warning

### DIFF
--- a/lib/processOptions.ts
+++ b/lib/processOptions.ts
@@ -83,11 +83,13 @@ export default (
   }
 
   let authorizerCert: ChannelCredentials;
+  if (disableTlsValidation) {
+    log("INSECURE CONNECTION");
+  }
   if (!disableTlsValidation && authorizerCertCAFile) {
     authorizerCert = getSSLCredentials(authorizerCertCAFile);
   } else {
     authorizerCert = credentials.createSsl();
-    log("INSECURE CONNECTION");
   }
 
   const instanceName =


### PR DESCRIPTION
log "insecure connection" only when the "disable TLS validation" flag is set.
