### PR TITLE
displayStateMaps returns plain JS object

### DIFF
--- a/lib/displayStateMap.ts
+++ b/lib/displayStateMap.ts
@@ -99,7 +99,7 @@ const displayStateMap = (optionsParam: DisplayStateMapOptions) => {
                 return;
               }
               if (response.hasPath()) {
-                resolve(response.getPath());
+                resolve(response.getPath()?.toJavaScript());
               } else {
                 reject("'displayStateMap' returned error: No path found");
                 return;
@@ -114,7 +114,7 @@ const displayStateMap = (optionsParam: DisplayStateMapOptions) => {
 
     try {
       const result = await callAuthorizer();
-      res.send(200).send(result);
+      res.status(200).send(result);
     } catch (err) {
       error(res, err as string);
     }


### PR DESCRIPTION
This PR fixes two bugs:
* `response.getPath()` returns a `struct_pb.Struct` instance that needs to converted to a simple JS object using `.toJavaScript()`. Otherwise we end up sending the full struct object, which is not what clients expect.
* It's not possible to call `send()` twice on the same response object.