### PR TITLE
update `setObject` to require `SetObjectRequest`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "cSpell.words": [
+    "Rego"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ The Express request object.
 
 #### packageName argument
 
-By default, `is` will follow the same heuristic behavior as `jwtAuthz` - it will infer the packge name from the policy name, HTTP method, and route path. If provided, the `packageName` argument will override this and specify a policy package to use.
+By default, `is` will follow the same heuristic behavior as `jwtAuthz` - it will infer the package name from the policy name, HTTP method, and route path. If provided, the `packageName` argument will override this and specify a policy package to use.
 
 By convention, Aserto Rego policies are named in the form `policyRoot.METHOD.path`. Following the node.js idiom, you can also pass it in as `policyRoot/METHOD/path`, and the path can contain the Express parameter syntax.
 
@@ -304,17 +304,19 @@ const relations = await directoryClient.relation(
 
 #### 'setObject' function
 
-`setObject({ ...Object$ })`:
+`setObject({ object: $Object })`:
 
 Create an object instance with the specified fields. For example:
 
 ```typescript
 user = directoryClient.setObject(
   {
-    type: "user",
-    key: "test-object",
-    properties: {
-      displayName: "test object"
+    object: {
+      type: "user",
+      key: "test-object",
+      properties: {
+        displayName: "test object"
+    }
   }
 );
 ```

--- a/lib/ds.ts
+++ b/lib/ds.ts
@@ -82,11 +82,8 @@ export class Directory {
   }
 
   async checkPermission(params: PartialMessage<CheckPermissionRequest>) {
-    const checkPermissionRequest = new CheckPermissionRequest(params);
     try {
-      const response = await this.ReaderClient.checkPermission(
-        checkPermissionRequest
-      );
+      const response = await this.ReaderClient.checkPermission(params);
       return response.check;
     } catch (error) {
       handleError(error, "checkPermission");
@@ -94,11 +91,8 @@ export class Directory {
   }
 
   async checkRelation(params: PartialMessage<CheckRelationRequest>) {
-    const checkRelationRequest = new CheckRelationRequest(params);
     try {
-      const response = await this.ReaderClient.checkRelation(
-        checkRelationRequest
-      );
+      const response = await this.ReaderClient.checkRelation(params);
       return response.check;
     } catch (error) {
       handleError(error, "checkRelation");
@@ -139,10 +133,7 @@ export class Directory {
 
   async objectMany(params: PartialMessage<GetObjectManyRequest>) {
     try {
-      const getObjectManyRequest = new GetObjectManyRequest(params);
-      const response = await this.ReaderClient.getObjectMany(
-        getObjectManyRequest
-      );
+      const response = await this.ReaderClient.getObjectMany(params);
       if (!response) {
         throw new Error("No response from directory service");
       }
@@ -154,9 +145,7 @@ export class Directory {
 
   async setObject(params: PartialMessage<SetObjectRequest>) {
     try {
-      const setObjectRequest = new SetObjectRequest(params);
-
-      const response = await this.WriterClient.setObject(setObjectRequest);
+      const response = await this.WriterClient.setObject(params);
       if (!response) {
         throw new Error("No response from directory service");
       }
@@ -238,8 +227,7 @@ export class Directory {
 
   async graph(params: PartialMessage<GetGraphRequest>) {
     try {
-      const getGraphRequest = new GetGraphRequest(params);
-      const response = await this.ReaderClient.getGraph(getGraphRequest);
+      const response = await this.ReaderClient.getGraph(params);
       if (!response) {
         throw new Error("No response from directory service");
       }

--- a/lib/ds.ts
+++ b/lib/ds.ts
@@ -32,7 +32,7 @@ import {
   UnaryRequest,
 } from "@bufbuild/connect";
 import { createGrpcTransport } from "@bufbuild/connect-node";
-import { AnyMessage, JsonValue, PartialMessage } from "@bufbuild/protobuf";
+import { AnyMessage, PartialMessage } from "@bufbuild/protobuf";
 
 export interface Config {
   url?: string;
@@ -152,11 +152,9 @@ export class Directory {
     }
   }
 
-  async setObject(params: JsonValue) {
+  async setObject(params: PartialMessage<SetObjectRequest>) {
     try {
-      const setObjectRequest = new SetObjectRequest().fromJson({
-        object: params,
-      });
+      const setObjectRequest = new SetObjectRequest(params);
 
       const response = await this.WriterClient.setObject(setObjectRequest);
       if (!response) {

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -17,6 +17,7 @@ import {
   GetObjectsResponse,
   GetRelationsResponse,
 } from "@aserto/node-directory/src/gen/cjs/aserto/directory/reader/v2/reader_pb";
+import { SetObjectRequest } from "@aserto/node-directory/src/gen/cjs/aserto/directory/writer/v2/writer_pb";
 import { Empty, JsonValue } from "@bufbuild/protobuf";
 export = {
   jwtAuthz,
@@ -107,7 +108,7 @@ export interface Directory {
   objectMany: (
     params: PartialMessage<GetObjectManyRequest>
   ) => Promise<Object$[]>;
-  setObject: (params: JsonValue) => Promise<Object$>;
+  setObject: (params: PartialMessage<SetObjectRequest>) => Promise<Object$>;
   deleteObject: (
     params: PartialMessage<ObjectIdentifier>
   ) => Promise<Empty | undefined>;


### PR DESCRIPTION
Before this change, you could pase any data to the set object request, now the method requires to pass a `SetObjectRequest`