### PR TITLE
update check response and exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,7 +508,7 @@ const relations = await directoryClient.relation({
 Create an object instance with the specified fields. For example:
 
 ```typescript
-const user = directoryClient.setObject(
+const user = await directoryClient.setObject(
   {
     object: {
       type: "user",
@@ -662,6 +662,8 @@ types:
     relations:
       ### display_name: group#member ###
       member: user
+    permissions:
+      read: member
 `);
 ```
 

--- a/README.md
+++ b/README.md
@@ -718,6 +718,14 @@ const resp = await directoryClient.import(importRequest);
 await (readAsyncIterable(resp))
 ```
 
+### Export
+
+```ts
+const response = await readAsyncIterable(
+  await directoryClient.export({ options: "all" })
+)
+```
+
 ## Deprecated Methods
 
 > Note: the `authorizerServiceUrl` option that is used throughout is no longer a URL, but the option name is retained for backward-compatibility. It is now expected to be a hostname that exposes a gRPC binding. Any "https://" prefix is stripped out of the value provided.

--- a/__tests__/directory/v3/index.test.ts
+++ b/__tests__/directory/v3/index.test.ts
@@ -149,7 +149,7 @@ describe("DirectoryV3", () => {
         params
       );
 
-      expect(result).toBe(true);
+      expect(result?.check).toBe(true);
 
       mockCheckPermission.mockReset();
     });
@@ -211,7 +211,7 @@ describe("DirectoryV3", () => {
       const result = await directory.checkRelation(params);
 
       expect(directory.ReaderClient.checkRelation).toHaveBeenCalledWith(params);
-      expect(result).toBe(true);
+      expect(result?.check).toBe(true);
 
       mockCheckRelation.mockReset();
     });
@@ -778,10 +778,9 @@ describe("DirectoryV3", () => {
         .spyOn(directory.ExporterClient, "export")
         .mockReturnValue(createAsyncIterable([new ExportResponse()]));
 
-      const params = { options: 1 };
-      await directory.export(params);
+      await directory.export({ options: "all" });
 
-      expect(mockExport).toHaveBeenCalledWith(params);
+      expect(mockExport).toHaveBeenCalledWith({ options: 24 });
 
       mockExport.mockReset();
     });
@@ -793,9 +792,7 @@ describe("DirectoryV3", () => {
           throw new Error("Directory service error");
         });
 
-      const params = { options: 1 };
-
-      await expect(directory.export(params)).rejects.toThrow(
+      await expect(directory.export({ options: "all" })).rejects.toThrow(
         "Directory service error"
       );
 

--- a/lib/directory/v3/index.ts
+++ b/lib/directory/v3/index.ts
@@ -322,26 +322,23 @@ export class DirectoryV3 {
 
   async import(params: AsyncIterable<PartialMessage<ImportRequest>>) {
     try {
-      const response = this.ImporterClient.import(params);
-
-      return await readAsyncIterable(response);
+      return this.ImporterClient.import(params);
     } catch (error) {
       handleError(error, "import");
+      return createAsyncIterable([]);
     }
   }
 
   async export(params: { options: DATA_TYPE_OPTIONS }) {
     try {
-      const response = this.ExporterClient.export(
+      return this.ExporterClient.export(
         new ExportRequest({
           options: DATA_TYPE[params.options] || DATA_TYPE["unknown"],
         })
       );
-
-      const data = await readAsyncIterable(response);
-      return data;
     } catch (error) {
       handleError(error, "export");
+      return createAsyncIterable([]);
     }
   }
 

--- a/lib/directory/v3/types.ts
+++ b/lib/directory/v3/types.ts
@@ -12,7 +12,12 @@ import {
   SetObjectRequest as SetObjectRequest$,
   SetRelationRequest as SetRelationRequest$,
 } from "@aserto/node-directory/src/gen/cjs/aserto/directory/writer/v3/writer_pb";
-import { JsonValue, PlainMessage, Struct } from "@bufbuild/protobuf";
+import {
+  JsonValue,
+  PartialMessage,
+  PlainMessage,
+  Struct,
+} from "@bufbuild/protobuf";
 
 import { NestedOmit, PartialExcept } from "../../util/types";
 
@@ -44,16 +49,13 @@ export type GetRelationRequest = PartialExcept<
   ["subjectRelation", "withObjects", "subjectId"]
 >;
 
-export type GetRelationsRequest = PartialExcept<
-  PlainMessage<GetRelationsRequest$>,
-  ["subjectRelation", "withObjects", "page.token"]
->;
+export type GetRelationsRequest = PartialMessage<GetRelationsRequest$>;
 
 export type SetObjectRequest = PartialExcept<
   NestedOmit<PlainMessage<SetObjectRequest$>, "object.properties"> & {
     object?: { properties?: { [key: string]: JsonValue } | Struct };
   },
-  ["object.etag"]
+  ["object.etag", "object.displayName"]
 >;
 
 export type DeleteObjectRequest = PartialExcept<


### PR DESCRIPTION
- updates `check` to provide the full response
- update `import` and `export` to return an `AsyncIterable`
- update GetRelationsRequest optional fields
- update export options