### PR TITLE
add tracing flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -924,6 +924,11 @@ Furthermore, when packaging a policy for deployment (e.g. in a Docker container)
 
 Alternately, to ignore TLS certificate validation when creating a TLS connection to the authorizer, you can set the `disableTlsValidation` option to `true` and avoid TLS certificate validation. This option is **not recommended for production**.
 
+## Debugging
+
+aserto-node provides a couple of environment variables that can be used to print debug information:
+`NODE_TRACE=true` - enables trace logging for the requests.
+`NODE_TRACE_MESSAGE=true` - logs the request payload for gRPC requests.
 
 ## Issue Reporting
 

--- a/README.md
+++ b/README.md
@@ -927,7 +927,9 @@ Alternately, to ignore TLS certificate validation when creating a TLS connection
 ## Debugging
 
 aserto-node provides a couple of environment variables that can be used to print debug information:
+
 `NODE_TRACE=true` - enables trace logging for the requests.
+
 `NODE_TRACE_MESSAGE=true` - logs the request payload for gRPC requests.
 
 ## Issue Reporting

--- a/lib/log.ts
+++ b/lib/log.ts
@@ -8,15 +8,20 @@ const logLevels = {
 
 const log = (message: string, level = "INFO") => {
   const timestamp = new Date().toISOString();
-  if (level === "ERROR") {
+  if (process.env.NODE_TRACE) {
     // eslint-disable-next-line no-console
-    console.error(`${timestamp} ${level}: ${message}`);
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    /* @ts-ignore */
-    //TODO: Remove this ts-ignore
-  } else if (logLevels[level] <= logLevels[currentLevel]) {
-    // eslint-disable-next-line no-console
-    console.log(`${timestamp} ${level}: aserto-node: ${message}`);
+    console.trace(`${timestamp} ${level}: ${message}`);
+  } else {
+    if (level === "ERROR") {
+      // eslint-disable-next-line no-console
+      console.error(`${timestamp} ${level}: ${message}`);
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      /* @ts-ignore */
+      //TODO: Remove this ts-ignore
+    } else if (logLevels[level] <= logLevels[currentLevel]) {
+      // eslint-disable-next-line no-console
+      console.log(`${timestamp} ${level}: aserto-node: ${message}`);
+    }
   }
 };
 


### PR DESCRIPTION
fixes: https://github.com/aserto-dev/aserto-node/issues/60

```
Trace: 2023-12-18T12:05:35.795Z INFO: {"policyContext":{"path":"peoplefinder","decisionsList":["visible","enabled"]},"identityContext":{"identity":"xxx","type":3},"options":{"pathSeparator":2},"resourceContext":{"fieldsMap":[]},"policyInstance":{"name":"policy-peoplefinder-rbac","instanceLabel":"policy-peoplefinder-rbac"}}
    at log (peoplefinder-acmecorp/@aserto/aserto-node/dist/log.js:14:17)
    at Object.sendMessage (peoplefinder-acmecorp/@aserto/aserto-node/dist/authorizer/index.js:37:39)
    at InterceptingCall.sendMessageWithContext (peoplefinder-acmecorp/node_modules/@grpc/grpc-js/build/src/client-interceptors.js:215:24)
    at InterceptingCall.sendMessage (peoplefinder-acmecorp/node_modules/@grpc/grpc-js/build/src/client-interceptors.js:229:14)
    at ServiceClientImpl.makeUnaryRequest (peoplefinder-acmecorp/node_modules/@grpc/grpc-js/build/src/client.js:200:14)
    at ServiceClientImpl.decisionTree (peoplefinder-acmecorp/node_modules/@grpc/grpc-js/build/src/make-client.js:105:19)
    at peoplefinder-acmecorp/@aserto/aserto-node/dist/authorizer/index.js:123:33
    at new Promise (<anonymous>)
    at Authorizer.<anonymous> (peoplefinder-acmecorp/@aserto/aserto-node/dist/authorizer/index.js:121:20)
    at Generator.next (<anonymous>)
Trace: 2023-12-18T12:05:36.165Z ERROR: 'decisionTree' returned error: 13 INTERNAL: E40000 an unknown error has occurred
    at log (peoplefinder-acmecorp/@aserto/aserto-node/dist/log.js:14:17)
    at peoplefinder-acmecorp/@aserto/aserto-node/dist/errorHandler.js:14:23
    at peoplefinder-acmecorp/@aserto/aserto-node/dist/displayStateMap.js:81:13
    at Generator.throw (<anonymous>)
    at rejected (peoplefinder-acmecorp/@aserto/aserto-node/dist/displayStateMap.js:6:65)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
POST /__displaystatemap 403 388.429 ms - 80
```