### PR TITLE
expose Directory Create Transport

### DIFF
--- a/lib/directory/v3/index.ts
+++ b/lib/directory/v3/index.ts
@@ -29,6 +29,7 @@ import {
   createPromiseClient,
   Interceptor,
   PromiseClient,
+  Transport,
 } from "@connectrpc/connect";
 import { createGrpcTransport } from "@connectrpc/connect-node";
 
@@ -88,6 +89,10 @@ export class DirectoryV3 {
   ImporterClient: PromiseClient<typeof Importer>;
   ExporterClient: PromiseClient<typeof Exporter>;
   ModelClient: PromiseClient<typeof Model>;
+  CreateTransport: (
+    config: ServiceConfig | undefined,
+    fallback: ServiceConfig | undefined
+  ) => Transport | undefined;
 
   constructor(config: DirectoryV3Config) {
     const baseServiceHeaders: Interceptor = (next) => async (req) => {
@@ -226,6 +231,8 @@ export class DirectoryV3 {
     this.ModelClient = !!modelGrpcTransport
       ? createPromiseClient(Model, modelGrpcTransport)
       : (nullModelProxy as unknown as PromiseClient<typeof Model>);
+
+    this.CreateTransport = createTransport;
   }
 
   async checkPermission(params: CheckPermissionRequest) {


### PR DESCRIPTION
Utility method to enable extending the directory v3 class with addition gRPC clients.
Using `CreateTransport` we ensure that the service is validated and initialed correctly.
eg:


```ts
class Ds0 extends DirectoryV3 {
  StoreClient: PromiseClient<typeof Store>

  constructor(config: DirectoryV3Config) {
    super(config)
    const storeTransport = this.CreateTransport(config, undefined)
    this.StoreClient = createPromiseClient(Store, storeTransport!)
  }

  async createTenant(params: PartialMessage<CreateTenantRequest>) {
    try {
      const response = await this.StoreClient.createTenant(params)

      return response.result
    } catch (error) {
      handleError(error, 'createTenant')
    }
  }
}
```