### PR TITLE
Send message body as resource context in DisplayStateMap

### DIFF
--- a/lib/authorizer/mapper/resource/body.ts
+++ b/lib/authorizer/mapper/resource/body.ts
@@ -1,0 +1,9 @@
+import { Request } from "express";
+
+import { ResourceContext } from "../../model/resourceContext";
+
+const BodyResourceMapper = (req: Request): ResourceContext => {
+  return req.body;
+};
+
+export default BodyResourceMapper;

--- a/lib/authorizer/mapper/resource/params.ts
+++ b/lib/authorizer/mapper/resource/params.ts
@@ -2,8 +2,8 @@ import { Request } from "express";
 
 import { ResourceContext } from "../../model/resourceContext";
 
-const ResourceParamsMapper = (req: Request): ResourceContext => {
+const ParamsResourceMapper = (req: Request): ResourceContext => {
   return req.params;
 };
 
-export default ResourceParamsMapper;
+export default ParamsResourceMapper;

--- a/lib/authorizer/middleware.ts
+++ b/lib/authorizer/middleware.ts
@@ -8,7 +8,7 @@ import { Authorizer } from ".";
 import JWTIdentityMapper from "./mapper/identity/jwt";
 import PolicyPathMapper from "./mapper/policy/path";
 import checkResourceMapper from "./mapper/resource/check";
-import ResourceParamsMapper from "./mapper/resource/params";
+import ParamsResourceMapper from "./mapper/resource/params";
 import policyContext from "./model/policyContext";
 import policyInstance from "./model/policyInstance";
 import { ResourceContext } from "./model/resourceContext";
@@ -145,7 +145,7 @@ export class Middleware {
           ? typeof this.resourceMapper === "function"
             ? await this.resourceMapper(req)
             : this.resourceMapper
-          : ResourceParamsMapper(req);
+          : ParamsResourceMapper(req);
 
         return [
           await this.client.Is({

--- a/lib/displayStateMap.ts
+++ b/lib/displayStateMap.ts
@@ -2,7 +2,7 @@ import { NextFunction, Request, Response } from "express";
 import { IdentityContext } from "@aserto/node-authorizer/src/gen/cjs/aserto/authorizer/v2/api/identity_context_pb";
 
 import { Authorizer } from "./authorizer";
-import ResourceParamsMapper from "./authorizer/mapper/resource/params";
+import BodyResourceMapper from "./authorizer/mapper/resource/body";
 import {
   IdentityMapper,
   PolicyMapper,
@@ -96,7 +96,7 @@ const displayStateMap = (
         ? typeof resourceMapper === "function"
           ? await resourceMapper(req)
           : resourceMapper
-        : ResourceParamsMapper(req);
+        : BodyResourceMapper(req);
 
       const policyInst =
         instanceName && instanceLabel


### PR DESCRIPTION
This PR modifies the default resource mapper used in the displayStateMap middleware.
Instead of using the same default mapper as the authorization middleware, which sends `req.params` as the resource context, the displayStateMap protocol expects the resource context to be sent in the request body (it's a POST).

The default authorization mapper is left unchanged and a new `BodyResourceMapper` is added as the default mapper for displayStateMap.