### PR TITLE
remove lib from the final package

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,12 +21,9 @@
     "test": "jest test --coverage --verbose --collectCoverageFrom='./lib/**'"
   },
   "files": [
-    "lib",
     "dist"
   ],
-  "imports": {
-    "@lib": "./lib"
-  },
+
   "repository": {
     "type": "git",
     "url": "git+https://github.com/aserto-dev/aserto-node.git"


### PR DESCRIPTION
This was a remnant from the initial package, before we switched to `tsc` and support commonjs.